### PR TITLE
Update build for macos

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,11 @@ fn main() {
                           .define("ENABLE_PLAYLIST", enable_playlist().as_str())
                           .build();
 
+  #[cfg(target_os = "macos")]
+  let dst = cmake::Config::new(PROJECTM_BUILD.as_str())
+                          .define("ENABLE_PLAYLIST", enable_playlist().as_str())
+                          .build(); 
+
   #[cfg(target_os = "ios")]
   let dst = cmake::Config::new(PROJECTM_BUILD.as_str())
                           .define("ENABLE_PLAYLIST", enable_playlist().as_str())


### PR DESCRIPTION
Per https://github.com/projectM-visualizer/projectm-sys/issues/1 this adds a configurable compilation macro for the `macos` target os. This now builds fine on macos:

```
❯ cargo build
   Compiling projectm-sys v1.0.4 (/Users/hehe/Projects/scratch/rust/projectm-sys)
    Finished dev [unoptimized + debuginfo] target(s) in 1.63s
```