### PR TITLE
build.rs: correct dynamic library name for Linux release build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -86,7 +86,7 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     if Ok("release".to_owned()) == env::var("PROFILE") {
-        println!("cargo:rustc-link-lib=dylib=libprojectM-4");
+        println!("cargo:rustc-link-lib=dylib=projectM-4");
 
         #[cfg(feature = "playlist")]
         println!("cargo:rustc-link-lib=dylib=projectM-4-playlist");

--- a/build.rs
+++ b/build.rs
@@ -86,7 +86,7 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     if Ok("release".to_owned()) == env::var("PROFILE") {
-        println!("cargo:rustc-link-lib=dylib=libprojectM=4");
+        println!("cargo:rustc-link-lib=dylib=libprojectM-4");
 
         #[cfg(feature = "playlist")]
         println!("cargo:rustc-link-lib=dylib=projectM-4-playlist");


### PR DESCRIPTION
Based on the context and the consistent usage of projectM-4 in the rest of the file, it appears that the equal sign (=) is a typo and should be replaced with a hyphen-minus (-). Current naming of the dynamic lib causes link failure when building on Linux with release profile.

Also, the prefix of `libprojectM-4` was causing errors, as on Linux systems the convention is to use the library name without the lib prefix.

Fixes: #4 